### PR TITLE
Add voice mode feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ChatInterface from "@/pages/ChatInterface";
 import MemoryManager from "@/pages/MemoryManager";
 import ProfileManager from "@/pages/ProfileManager";
 import Settings from "@/pages/Settings";
+import VoiceMode from "@/pages/VoiceMode";
 import NotFound from "./pages/NotFound";
 import { PWAInstallPrompt } from "@/components/pwa/PWAInstallPrompt";
 import "./animations.css";
@@ -148,10 +149,11 @@ const handleKeyboardHide = () => {
                   <Routes>
                     <Route path="/" element={<MainLayout />}>
                       <Route index element={<ChatInterface keyboardHeight={keyboardHeight} />} />
-                      <Route path="memory" element={<MemoryManager />} />
-                      <Route path="profiles" element={<ProfileManager />} />
-                      <Route path="settings" element={<Settings />} />
-                    </Route>
+                    <Route path="memory" element={<MemoryManager />} />
+                    <Route path="profiles" element={<ProfileManager />} />
+                    <Route path="settings" element={<Settings />} />
+                    <Route path="voice" element={<VoiceMode />} />
+                  </Route>
                     <Route path="*" element={<NotFound />} />
                   </Routes>
                   <PWAInstallPrompt />

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -4,6 +4,7 @@ import {
   MessageSquare,
   Brain,
   Settings,
+  Mic,
   Plus,
   Trash2,
   User,
@@ -35,6 +36,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 const staticMenuItems = [
   { title: 'Memory', url: '/memory', icon: Brain },
   { title: 'Profiles', url: '/profiles', icon: User },
+  { title: 'Voice', url: '/voice', icon: Mic },
   { title: 'Settings', url: '/settings', icon: Settings }
 ];
 

--- a/src/pages/VoiceMode.css
+++ b/src/pages/VoiceMode.css
@@ -1,0 +1,42 @@
+.voice-mode {
+  position: fixed;
+  inset: 0;
+  background: black;
+  color: white;
+  overflow: hidden;
+  user-select: none;
+  touch-action: manipulation;
+}
+.voice-mode canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.voice-name {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: clamp(20px, 5vw, 32px);
+  font-weight: bold;
+  letter-spacing: 3px;
+  text-shadow: 0 0 20px rgba(255,255,255,0.5);
+  pointer-events: none;
+  opacity: 0.9;
+}
+.voice-hint {
+  position: absolute;
+  bottom: 50%;
+  left: 50%;
+  transform: translate(-50%, 50%);
+  font-size: 14px;
+  opacity: 0.8;
+  pointer-events: none;
+  background: rgba(0,0,0,0.7);
+  padding: 10px 20px;
+  border-radius: 20px;
+  transition: opacity 0.3s ease;
+}
+.voice-mode.active .voice-hint {
+  opacity: 0.4;
+}

--- a/src/pages/VoiceMode.tsx
+++ b/src/pages/VoiceMode.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { useChat, Message } from '@/contexts/ChatContext';
+import './VoiceMode.css';
+
+declare global {
+  interface SpeechRecognitionEvent extends Event {
+    results: ArrayLike<{ 0: { transcript: string } }>;
+  }
+  interface SpeechRecognition {
+    lang: string;
+    interimResults: boolean;
+    onresult: ((e: SpeechRecognitionEvent) => void) | null;
+    onend: (() => void) | null;
+    start(): void;
+    stop(): void;
+  }
+  interface Window {
+    SpeechRecognition?: { new(): SpeechRecognition };
+    webkitSpeechRecognition?: { new(): SpeechRecognition };
+  }
+}
+
+const VoiceMode: React.FC = () => {
+  const { sendMessage, currentConversation, isTyping } = useChat();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const [listening, setListening] = useState(false);
+  const [waitingReply, setWaitingReply] = useState(false);
+  const lastMessageRef = useRef<Message | null>(null);
+
+  useEffect(() => {
+    const SpeechRecognitionCtor = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognitionCtor) return;
+    const recog = new SpeechRecognitionCtor();
+    recog.lang = 'en-US';
+    recog.interimResults = false;
+    recog.onresult = (e: SpeechRecognitionEvent) => {
+      const text = Array.from(e.results).map((r) => r[0].transcript).join('');
+      if (text.trim()) {
+        sendMessage(text.trim());
+        setWaitingReply(true);
+      }
+    };
+    recog.onend = () => {
+      if (listening) recog.start();
+    };
+    recognitionRef.current = recog;
+  }, [sendMessage, listening]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+    let frame = 0;
+    const draw = () => {
+      const { width, height } = canvas;
+      ctx.clearRect(0, 0, width, height);
+      const radius = Math.min(width, height) * 0.25 * (listening ? 1.1 + 0.05 * Math.sin(frame / 5) : 1);
+      const x = width / 2;
+      const y = height / 2;
+      const gradient = ctx.createRadialGradient(x, y, radius * 0.2, x, y, radius);
+      gradient.addColorStop(0, '#9048f8');
+      gradient.addColorStop(1, '#1b052c');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+      frame += 1;
+      requestAnimationFrame(draw);
+    };
+    draw();
+    return () => {
+      window.removeEventListener('resize', resize);
+    };
+  }, [listening]);
+
+  useEffect(() => {
+    if (waitingReply && !isTyping && currentConversation) {
+      const last = currentConversation.messages[currentConversation.messages.length - 1];
+      if (last && last.role === 'assistant' && last !== lastMessageRef.current) {
+        lastMessageRef.current = last;
+        const utter = new SpeechSynthesisUtterance(last.content);
+        utter.lang = 'en-US';
+        window.speechSynthesis.speak(utter);
+        setWaitingReply(false);
+      }
+    }
+  }, [waitingReply, isTyping, currentConversation]);
+
+  const start = () => {
+    recognitionRef.current?.start();
+    setListening(true);
+  };
+  const stop = () => {
+    recognitionRef.current?.stop();
+    setListening(false);
+  };
+  const toggle = useCallback(() => {
+    if (listening) {
+      stop();
+    } else {
+      start();
+    }
+  }, [listening]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        e.preventDefault();
+        toggle();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [listening, toggle]);
+
+  return (
+    <div className={`voice-mode ${listening ? 'active' : ''}`} onClick={toggle}>
+      <canvas ref={canvasRef} />
+      <div className="voice-name">NYX VOICE</div>
+      <div className="voice-hint">{listening ? 'Listening...' : 'Tap or press Space to speak'}</div>
+    </div>
+  );
+};
+
+export default VoiceMode;


### PR DESCRIPTION
## Summary
- add `VoiceMode` page with speech recognition and TTS
- style voice mode canvas and UI
- register `/voice` route in app
- add Voice entry to sidebar navigation

## Testing
- `npm run lint` *(fails: multiple errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687a5456dcd0832a9d842fe1dd2c3e06